### PR TITLE
Catch date comparison error

### DIFF
--- a/fetch-curecode.r
+++ b/fetch-curecode.r
@@ -52,7 +52,7 @@ main: funct [/local ticket-num ticket-date] [
         fail "Could not load most recent change."
     ]
 
-    changes: either local-date >= remote-date [
+    changes: either attempt [ local-date >= remote-date ] [
         ;; Local timestamp is equal/newer than most recent remote. No changes
         ;; to fetch.
         []


### PR DESCRIPTION
If there is no state.r file I get the following error:
  Script error: cannot compare none! with date!
Adding an attempt wrapper around the comparison helps
